### PR TITLE
Draft new fiber bundle structure

### DIFF
--- a/geomstats/geometry/discrete_curves.py
+++ b/geomstats/geometry/discrete_curves.py
@@ -69,6 +69,10 @@ class DiscreteCurves(Manifold):
             dim=dim, shape=(k_sampling_points,) + ambient_manifold.shape, equip=equip
         )
 
+        self._quotient_map = {
+            (SRVMetric, "reparametrizations"): (ShapeBundle, SRVQuotientMetric),
+        }
+
     @staticmethod
     def default_metric():
         """Metric to equip the space with if equip is True."""
@@ -1461,27 +1465,7 @@ class SRVMetric(PullbackDiffeoMetric):
         return n_points * gs.matmul(mat_space_deriv, curve)
 
 
-class SRVPreShapeSpace(DiscreteCurves):
-    def __init__(self, ambient_manifold, k_sampling_points=10, equip=True):
-        super().__init__(
-            ambient_manifold=ambient_manifold,
-            k_sampling_points=k_sampling_points,
-            equip=False,
-        )
-
-        if not isinstance(self, FiberBundle):
-            self.fiber_bundle = SRVShapeBundle(ambient_manifold, k_sampling_points)
-
-        if equip:
-            self.equip_with_metric(self.default_metric())
-
-    @staticmethod
-    def default_metric():
-        """Metric to equip the space with if equip is True."""
-        return SRVQuotientMetric
-
-
-class SRVShapeBundle(FiberBundle, SRVPreShapeSpace):
+class ShapeBundle(FiberBundle):
     """Principal bundle of shapes of curves induced by the SRV metric.
 
     The space of parameterized curves is the total space of a principal
@@ -1513,17 +1497,9 @@ class SRVShapeBundle(FiberBundle, SRVPreShapeSpace):
         pp. 40-70, 2019.
     """
 
-    def __init__(self, ambient_manifold, k_sampling_points=10):
-        super().__init__(
-            ambient_manifold=ambient_manifold,
-            k_sampling_points=k_sampling_points,
-        )
-        self.l2_curves_metric = L2CurvesMetric(self)
-
-    @staticmethod
-    def default_metric():
-        """Metric to equip the space with if equip is True."""
-        return SRVMetric
+    def __init__(self, space):
+        super().__init__(space=space)
+        self.l2_curves_metric = L2CurvesMetric(space)
 
     def vertical_projection(self, tangent_vec, point, return_norm=False):
         """Compute vertical part of tangent vector at base point.
@@ -1804,7 +1780,7 @@ class SRVShapeBundle(FiberBundle, SRVPreShapeSpace):
             counter = 0
 
             while gap > threshold:
-                srv_geod_fun = self.metric.geodesic(
+                srv_geod_fun = self.space.metric.geodesic(
                     initial_point=initial_curve, end_point=current_end_curve
                 )
                 geod = srv_geod_fun(t)
@@ -1815,7 +1791,7 @@ class SRVShapeBundle(FiberBundle, SRVPreShapeSpace):
                 )
 
                 space_deriv = SRVMetric.space_derivative(geod)
-                space_deriv_norm = self.ambient_manifold.metric.norm(space_deriv)
+                space_deriv_norm = self.space.ambient_manifold.metric.norm(space_deriv)
 
                 repar = construct_reparametrization(vertical_norm, space_deriv_norm)
 
@@ -1922,7 +1898,7 @@ class SRVQuotientMetric(QuotientMetric):
         horizontal_geod_velocity = n_times * (
             horizontal_geod[:-1] - horizontal_geod[1:]
         )
-        velocity_norms = self.fiber_bundle.metric.norm(
+        velocity_norms = self.fiber_bundle.space.metric.norm(
             horizontal_geod_velocity, horizontal_geod[:-1]
         )
         return gs.sum(velocity_norms) / n_times

--- a/geomstats/geometry/fiber_bundle.py
+++ b/geomstats/geometry/fiber_bundle.py
@@ -9,11 +9,10 @@ from abc import ABC
 from scipy.optimize import minimize
 
 import geomstats.backend as gs
-from geomstats.geometry.manifold import Manifold
 from geomstats.vectorization import get_batch_shape
 
 
-class FiberBundle(Manifold, ABC):
+class FiberBundle(ABC):
     """Class for (principal) fiber bundles.
 
     This class implements abstract methods for fiber bundles, or more
@@ -28,17 +27,16 @@ class FiberBundle(Manifold, ABC):
     group_action : callable
         Right group action. It must take as input a point of the total space
         and an element of the group, and return a point of the total space.
-
     """
 
     def __init__(
         self,
+        space,
         group=None,
         group_action=None,
         group_dim=None,
-        **kwargs,
     ):
-        super().__init__(**kwargs)
+        self.space = space
         self.group = group
 
         if group_action is None and group is not None:
@@ -149,7 +147,7 @@ class FiberBundle(Manifold, ABC):
         group = self.group
         group_action = self.group_action
 
-        max_shape = get_batch_shape(self, point, base_point) + (self.group_dim,)
+        max_shape = get_batch_shape(self.space, point, base_point) + (self.group_dim,)
 
         if group is not None:
 
@@ -172,7 +170,7 @@ class FiberBundle(Manifold, ABC):
             raise ValueError("Either the group of its action must be known")
 
         objective_with_grad = gs.autodiff.value_and_grad(
-            lambda param: self.metric.squared_dist(wrap(param), base_point),
+            lambda param: self.space.metric.squared_dist(wrap(param), base_point),
             to_numpy=True,
         )
 

--- a/geomstats/geometry/pre_shape.py
+++ b/geomstats/geometry/pre_shape.py
@@ -45,20 +45,19 @@ class PreShapeSpace(LevelSet):
 
         super().__init__(
             dim=m_ambient * (k_landmarks - 1) - 1,
-            equip=False,
+            equip=equip,
         )
-        if not isinstance(self, FiberBundle):
-            self.fiber_bundle = PreShapeSpaceBundle(k_landmarks, m_ambient)
-
-        if equip:
-            self.equip_with_metric(self.default_metric())
 
         self._sphere = Hypersphere(dim=m_ambient * k_landmarks - 1)
+
+        self._quotient_map = {
+            (PreShapeMetric, "rotations"): (PreShapeSpaceBundle, KendallShapeMetric),
+        }
 
     @staticmethod
     def default_metric():
         """Metric to equip the space with if equip is True."""
-        return KendallShapeMetric
+        return PreShapeMetric
 
     def _define_embedding_space(self):
         return Matrices(self.k_landmarks, self.m_ambient)
@@ -102,8 +101,14 @@ class PreShapeSpace(LevelSet):
         -------
         projected_point : array-like, shape=[..., k_landmarks, m_ambient]
             Point projected on the pre-shape space.
+
+        Notes
+        -----
+        * Requires space to be equipped.
         """
-        return self.fiber_bundle.projection(point)
+        centered_point = self.center(point)
+        frob_norm = self.metric.norm(centered_point)
+        return gs.einsum("...,...ij->...ij", 1.0 / frob_norm, centered_point)
 
     def random_point(self, n_samples=1, bound=1.0):
         """Sample in the pre-shape space from the uniform distribution.
@@ -136,8 +141,16 @@ class PreShapeSpace(LevelSet):
         -------
         samples : array-like, shape=[..., k_landmarks, m_ambient]
             Points sampled on the pre-shape space.
+
+        Notes
+        -----
+        * Requires space to be equipped.
         """
-        return self.fiber_bundle.random_uniform(n_samples)
+        samples = self._sphere.random_uniform(n_samples)
+        samples = gs.reshape(samples, (-1, self.k_landmarks, self.m_ambient))
+        if n_samples == 1:
+            samples = samples[0]
+        return self.projection(samples)
 
     @staticmethod
     def is_centered(point, atol=gs.atol):
@@ -195,78 +208,10 @@ class PreShapeSpace(LevelSet):
         tangent_vec : array-like, shape=[..., k_landmarks, m_ambient]
             Tangent vector in the tangent space of the pre-shape space
             at the base point.
-        """
-        return self.fiber_bundle.to_tangent(vector, base_point)
 
-
-class PreShapeSpaceBundle(FiberBundle, PreShapeSpace):
-    def __init__(self, k_landmarks, m_ambient):
-        super().__init__(
-            k_landmarks=k_landmarks,
-            m_ambient=m_ambient,
-        )
-
-    @staticmethod
-    def default_metric():
-        """Metric to equip the space with if equip is True."""
-        return PreShapeMetric
-
-    def projection(self, point):
-        """Project a point on the pre-shape space.
-
-        Parameters
-        ----------
-        point : array-like, shape=[..., k_landmarks, m_ambient]
-            Point in Matrices space.
-
-        Returns
-        -------
-        projected_point : array-like, shape=[..., k_landmarks, m_ambient]
-            Point projected on the pre-shape space.
-        """
-        centered_point = self.center(point)
-        frob_norm = self.metric.norm(centered_point)
-        return gs.einsum("...,...ij->...ij", 1.0 / frob_norm, centered_point)
-
-    def random_uniform(self, n_samples=1):
-        """Sample in the pre-shape space from the uniform distribution.
-
-        Parameters
-        ----------
-        n_samples : int
-            Number of samples.
-            Optional, default: 1.
-
-        Returns
-        -------
-        samples : array-like, shape=[..., k_landmarks, m_ambient]
-            Points sampled on the pre-shape space.
-        """
-        samples = self._sphere.random_uniform(n_samples)
-        samples = gs.reshape(samples, (-1, self.k_landmarks, self.m_ambient))
-        if n_samples == 1:
-            samples = samples[0]
-        return self.projection(samples)
-
-    def to_tangent(self, vector, base_point):
-        """Project a vector to the tangent space.
-
-        Project a vector in the embedding matrix space
-        to the tangent space of the pre-shape space at a base point.
-
-        Parameters
-        ----------
-        vector : array-like, shape=[..., k_landmarks, m_ambient]
-            Vector in Matrix space.
-        base_point : array-like, shape=[..., k_landmarks, m_ambient]
-            Point on the pre-shape space defining the tangent space,
-            where the vector will be projected.
-
-        Returns
-        -------
-        tangent_vec : array-like, shape=[..., k_landmarks, m_ambient]
-            Tangent vector in the tangent space of the pre-shape space
-            at the base point.
+        Notes
+        -----
+        * Requires space to be equipped.
         """
         if not gs.all(self.is_centered(base_point)):
             raise ValueError("The base_point does not belong to the pre-shape space")
@@ -276,6 +221,8 @@ class PreShapeSpaceBundle(FiberBundle, PreShapeSpace):
         coef = inner_prod / sq_norm
         return vector - gs.einsum("...,...ij->...ij", coef, base_point)
 
+
+class PreShapeSpaceBundle(FiberBundle):
     def align(self, point, base_point, **kwargs):
         """Align point to base_point.
 
@@ -354,7 +301,7 @@ class PreShapeSpaceBundle(FiberBundle, PreShapeSpace):
             Boolean denoting if tangent vector is horizontal.
         """
         product = gs.matmul(Matrices.transpose(tangent_vec), base_point)
-        is_tangent = self.is_tangent(tangent_vec, base_point, atol)
+        is_tangent = self.space.is_tangent(tangent_vec, base_point, atol)
         is_symmetric = Matrices.is_symmetric(product, atol)
         return gs.logical_and(is_tangent, is_symmetric)
 
@@ -467,13 +414,13 @@ class PreShapeSpaceBundle(FiberBundle, PreShapeSpace):
         .. [Pennec] Pennec, Xavier. Computing the curvature and its gradient
         in Kendall shape spaces. Unpublished.
         """
-        if not gs.all(self.belongs(base_point)):
+        if not gs.all(self.space.belongs(base_point)):
             raise ValueError("The base_point does not belong to the pre-shape space")
         if not gs.all(self.is_horizontal(horizontal_vec_x, base_point)):
             raise ValueError("Tangent vector x is not horizontal")
         if not gs.all(self.is_horizontal(horizontal_vec_y, base_point)):
             raise ValueError("Tangent vector y is not horizontal")
-        if not gs.all(self.is_tangent(nabla_x_y, base_point)):
+        if not gs.all(self.space.is_tangent(nabla_x_y, base_point)):
             raise ValueError("Vector nabla_x_y is not tangent")
         a_x_y = self.integrability_tensor(
             horizontal_vec_x, horizontal_vec_y, base_point
@@ -483,9 +430,9 @@ class PreShapeSpaceBundle(FiberBundle, PreShapeSpace):
                 "Tangent vector nabla_x_y is not the gradient "
                 "of a horizontal distribution"
             )
-        if not gs.all(self.is_tangent(tangent_vec_e, base_point)):
+        if not gs.all(self.space.is_tangent(tangent_vec_e, base_point)):
             raise ValueError("Tangent vector e is not tangent")
-        if not gs.all(self.is_tangent(nabla_x_e, base_point)):
+        if not gs.all(self.space.is_tangent(nabla_x_e, base_point)):
             raise ValueError("Vector nabla_x_e is not tangent")
 
         p_top = Matrices.transpose(base_point)
@@ -517,7 +464,9 @@ class PreShapeSpaceBundle(FiberBundle, PreShapeSpace):
             x_top, tangent_vec_e_sym
         )
 
-        scal_x_a_y_e = self.metric.inner_product(horizontal_vec_x, a_y_e, base_point)
+        scal_x_a_y_e = self.space.metric.inner_product(
+            horizontal_vec_x, a_y_e, base_point
+        )
 
         nabla_x_a_y_e = (
             gs.matmul(base_point, sylv_p(tmp_tangent_vec_p))
@@ -571,7 +520,7 @@ class PreShapeSpaceBundle(FiberBundle, PreShapeSpace):
         in Kendall shape spaces. Unpublished.
         """
         # Vectors X and Y have to be horizontal.
-        if not gs.all(self.is_centered(base_point)):
+        if not gs.all(self.space.is_centered(base_point)):
             raise ValueError("The base_point does not belong to the pre-shape space")
         if not gs.all(self.is_horizontal(horizontal_vec_x, base_point)):
             raise ValueError("Tangent vector x is not horizontal")
@@ -662,7 +611,7 @@ class PreShapeSpaceBundle(FiberBundle, PreShapeSpace):
         .. [Pennec] Pennec, Xavier. Computing the curvature and its gradient
         in Kendall shape spaces. Unpublished.
         """
-        if not gs.all(self.is_centered(base_point)):
+        if not gs.all(self.space.is_centered(base_point)):
             raise ValueError("The base_point does not belong to the pre-shape space")
         if not gs.all(self.is_horizontal(horizontal_vec_x, base_point)):
             raise ValueError("Tangent vector x is not horizontal")
@@ -1079,8 +1028,10 @@ class KendallShapeMetric(QuotientMetric):
         horizontal_b = self.fiber_bundle.horizontal_projection(direction, base_point)
 
         def force(state, time):
-            gamma_t = self.fiber_bundle.metric.exp(time * horizontal_b, base_point)
-            speed = self.fiber_bundle.metric.parallel_transport(
+            gamma_t = self.fiber_bundle.space.metric.exp(
+                time * horizontal_b, base_point
+            )
+            speed = self.fiber_bundle.space.metric.parallel_transport(
                 horizontal_b, base_point, time * horizontal_b
             )
             coef = self.inner_product(speed, state, gamma_t)

--- a/geomstats/geometry/quotient_metric.py
+++ b/geomstats/geometry/quotient_metric.py
@@ -25,11 +25,14 @@ class QuotientMetric(RiemannianMetric):
     """
 
     def __init__(self, space, fiber_bundle=None, signature=None):
-        if fiber_bundle is None:
-            fiber_bundle = space.fiber_bundle
-
-        self.fiber_bundle = fiber_bundle
+        self._fiber_bundle = fiber_bundle
         super().__init__(space=space, signature=signature)
+
+    @property
+    def fiber_bundle(self):
+        if self._fiber_bundle is None:
+            return self._space.fiber_bundle
+        return self._fiber_bundle
 
     def inner_product(
         self, tangent_vec_a, tangent_vec_b, base_point=None, fiber_point=None
@@ -71,7 +74,7 @@ class QuotientMetric(RiemannianMetric):
         horizontal_b = self.fiber_bundle.horizontal_lift(
             tangent_vec_b, fiber_point=fiber_point
         )
-        return self.fiber_bundle.metric.inner_product(
+        return self.fiber_bundle.space.metric.inner_product(
             horizontal_a, horizontal_b, fiber_point
         )
 
@@ -96,7 +99,7 @@ class QuotientMetric(RiemannianMetric):
             tangent_vec, fiber_point=lift
         )
         return self.fiber_bundle.riemannian_submersion(
-            self.fiber_bundle.metric.exp(horizontal_vec, lift)
+            self.fiber_bundle.space.metric.exp(horizontal_vec, lift)
         )
 
     def log(self, point, base_point, **kwargs):
@@ -119,7 +122,7 @@ class QuotientMetric(RiemannianMetric):
         bp_fiber = self.fiber_bundle.lift(base_point)
         aligned = self.fiber_bundle.align(fiber_point, bp_fiber, **kwargs)
         return self.fiber_bundle.tangent_riemannian_submersion(
-            self.fiber_bundle.metric.log(aligned, bp_fiber), bp_fiber
+            self.fiber_bundle.space.metric.log(aligned, bp_fiber), bp_fiber
         )
 
     def squared_dist(self, point_a, point_b, **kwargs):
@@ -140,7 +143,7 @@ class QuotientMetric(RiemannianMetric):
         lift_a = self.fiber_bundle.lift(point_a)
         lift_b = self.fiber_bundle.lift(point_b)
         aligned = self.fiber_bundle.align(lift_a, lift_b, **kwargs)
-        return self.fiber_bundle.metric.squared_dist(aligned, lift_b)
+        return self.fiber_bundle.space.metric.squared_dist(aligned, lift_b)
 
     def curvature(self, tangent_vec_a, tangent_vec_b, tangent_vec_c, base_point):
         r"""Compute the curvature.
@@ -192,7 +195,7 @@ class QuotientMetric(RiemannianMetric):
         horizontal_b = bundle.horizontal_lift(tangent_vec_b, base_point)
         horizontal_c = bundle.horizontal_lift(tangent_vec_c, base_point)
 
-        top_curvature = bundle.metric.curvature(
+        top_curvature = bundle.space.metric.curvature(
             horizontal_a, horizontal_b, horizontal_c, fiber_point
         )
         projected_top_curvature = bundle.tangent_riemannian_submersion(
@@ -283,7 +286,7 @@ class QuotientMetric(RiemannianMetric):
         nabla_h_y = bundle.integrability_tensor(hor_h, hor_y, point_fiber)
         nabla_h_z = bundle.integrability_tensor(hor_h, hor_z, point_fiber)
 
-        nabla_curvature_top = bundle.metric.curvature_derivative(
+        nabla_curvature_top = bundle.space.metric.curvature_derivative(
             hor_h, hor_x, hor_y, hor_z, point_fiber
         )
 
@@ -391,7 +394,7 @@ class QuotientMetric(RiemannianMetric):
         nabla_x_x = gs.zeros_like(hor_x)
         nabla_x_y = bundle.integrability_tensor(hor_x, hor_y, point_fiber)
 
-        nabla_curvature_top = bundle.metric.curvature_derivative(
+        nabla_curvature_top = bundle.space.metric.curvature_derivative(
             hor_x, hor_x, hor_y, hor_y, point_fiber
         )
 


### PR DESCRIPTION
@ninamiolane, @alebrigant here a draft implementation of our `FiberBundle`/`QuotientMetric` discussion. I'm comparing against the `metric-refactor` branch so  if is easier to see how much it changes from there.

Let's consider the two scenarios for `FiberBundle`. In scenario 1 we explicitly know the total space  and the base. In scenario 2 we don't have access to base. Let's start by scenario 2, which can be exemplified by `discrete_curves` and `PreShapeSpace`.

Following our discussion, now we can do for `DiscreteCurves`:

```python
ambient_manifold = Euclidean(dim=dim)
space = DiscreteCurves(
    ambient_manifold, k_sampling_points=k_sampling_points, equip=False,
)

space.equip_with_metric(SRVMetric)
space.equip_with_group_action("reparametrizations")   # for now group actions are str -> to extend in the future

space.equip_with_quotient_structure()  # uses "map" approach

# we have now
space.quotient_metric  # SRVQuotientMetric
space.fiber_bundle  # can be used for e.g. `align` 
```

`FiberBundle` also has access to `space`. It is not a `Manifold` anymore: it simply needs to implement the methods that arise from a given combination of compatible metrics and group actions.

For `PreShapeSpace`:

```python
space = PreShapeSpace(k_landmarks, m_ambient, equip=False)
space.equip_with_metric(PreShapeSpaceMetric)

space.equip_with_group_action("rotations")
space.equip_with_quotient_structure()

# we have now
space.quotient_metric  # KendallShapeMetric
space.fiber_bundle  # can be used for e.g. `align` 
```

So now, each of the spaces has two metrics: `metric` and `quotient_metric`. Imagine now we have an estimator that receives an equipped space. Within the estimator we do `space.metric`. This means if we use this `equipped_space` idea, we need to find out a way of telling the estimator which is the proper metric to use. (The alternative is to always pass `space` and `metric`, but it conflicts with our ideas of not using metrics in isolation; it will also be cumbersome and error prone doing so).

To overcome this, I think we should have what I (for now) call `active_metric`. By default `active_metric` is `metric`. This way, we can do something like:

```python

estimator = FrechetMean(space)

# uses `metric`
estimator.fit()

space.set_active_metric("quotient_metric")
# uses quotient_metric
estimator.fit()
```

The estimators need, of course, to be aware of this change, which mean that they should call `space.active_metric` (this was the way I solved the "tests" problem we've discuss the other day).

Finally, let's come back to scenario 1. I'm using what I call `GeneralLinearBuresWassersteinBundle` which has `GeneralLinear` (with `MatricesMetric`) as total space and `SPDMatrices` as base. This is a good example, because `SPDMatrices` equipped with the corresponding `QuotientMetric` corresponds to `SPDMatrices` equipped with `SPDBuresWassersteinMetric`, which means we can tests one against the other. 


```python
space = SPDMatrices(n=n, equip=False)

total_space = GeneralLinear(n=n, equip=False)
total_space.equip_with_metric(MatricesMetric)

bundle = GeneralLinearBuresWassersteinBundle(total_space)

space.equip_with_metric(QuotientMetric, fiber_bundle=bundle)

# we only have one metric: `space.metric`
```

I'm keeping this example very generic (e.g. we could have created a metric that hides the creation of the bundle).


Overall I would say the solution is quite satisfying. I've already done tests (with new framework) to several of these changes and with exceptions in `SRVQuotientMetric`, everything is passing.

What are your thoughts?

@nguigs, I think we may also be interested in this.